### PR TITLE
feat: add build script

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -1,0 +1,48 @@
+import { build } from 'esbuild';
+import { rm, mkdir, cp } from 'fs/promises';
+import path from 'path';
+
+const outDir = path.resolve('dist');
+
+async function clean() {
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(outDir, { recursive: true });
+}
+
+async function copyStatic() {
+  const files = ['manifest.json', 'popup.html', 'index.html', 'metadata.json'];
+  for (const file of files) {
+    try {
+      await cp(file, path.join(outDir, file));
+    } catch (err) {
+      // ignore if file does not exist
+    }
+  }
+  await cp('icons', path.join(outDir, 'icons'), { recursive: true });
+  await cp('lib', path.join(outDir, 'lib'), { recursive: true });
+}
+
+async function buildScripts() {
+  await build({
+    entryPoints: ['background.ts', 'content.ts'],
+    outdir: outDir,
+    bundle: true,
+    format: 'iife',
+    target: ['chrome110'],
+    sourcemap: true,
+  });
+
+  await build({
+    entryPoints: ['popup.tsx'],
+    outdir: outDir,
+    bundle: true,
+    format: 'esm',
+    target: ['chrome110'],
+    sourcemap: true,
+    external: ['react', 'react-dom', 'react-dom/client'],
+  });
+}
+
+await clean();
+await buildScripts();
+await copyStatic();

--- a/popup.html
+++ b/popup.html
@@ -5,9 +5,18 @@
     <title>Pricing Co-Pilot</title>
     <meta charset="UTF-8" />
     <script src="https://cdn.tailwindcss.com"></script>
+    <script type="importmap">
+    {
+      "imports": {
+        "react-dom/": "https://aistudiocdn.com/react-dom@^19.1.1/",
+        "react/": "https://aistudiocdn.com/react@^19.1.1/",
+        "react": "https://aistudiocdn.com/react@^19.1.1"
+      }
+    }
+    </script>
   </head>
   <body class="w-[350px] h-[450px] bg-slate-900 text-white font-sans">
     <div id="root"></div>
-    <script src="popup.js"></script>
+    <script type="module" src="popup.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add esbuild script to bundle background, content, and popup files
- load React via import map in popup page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c09e59e4d483319766a583d72a90ed