### PR TITLE
fix: bundle Tailwind locally and tighten CSP

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1,17 +1,15 @@
 import type { Message, WorkflowState, ContentScriptMessage, ContentScriptResponse } from './types';
 import { WorkflowStatus } from './types';
-
 // FIX: Use a global declaration for 'chrome' to resolve TypeScript errors when @types/chrome is not available.
 declare const chrome: any;
+declare function importScripts(...urls: string[]): void;
+declare const JSZip: any;
 
-// The JSZip library is loaded into the service worker's global scope.
-// This is the correct way to load external scripts in a Manifest V3 service worker.
 try {
-    importScripts('lib/jszip.min.js');
+  importScripts('lib/jszip.min.js');
 } catch (e) {
-    console.error('Could not import jszip.min.js', e);
+  console.error("Could not import jszip.min.js", e);
 }
-declare var JSZip: any;
 
 let state: WorkflowState = {
     status: WorkflowStatus.IDLE,

--- a/build.mjs
+++ b/build.mjs
@@ -1,0 +1,67 @@
+import { build } from 'esbuild';
+import { rm, mkdir, cp, readFile, writeFile } from 'fs/promises';
+import { exec as execCb } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
+
+const exec = promisify(execCb);
+
+const outDir = path.resolve('dist');
+
+async function clean() {
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(outDir, { recursive: true });
+}
+
+async function copyStatic() {
+  const files = ['manifest.json', 'popup.html', 'metadata.json'];
+  for (const file of files) {
+    try {
+      await cp(file, path.join(outDir, file));
+    } catch (err) {
+      // ignore if file does not exist
+    }
+  }
+  await cp('icons', path.join(outDir, 'icons'), { recursive: true });
+
+  // Sanitize JSZip to avoid octal escape sequences that break in strict mode
+  try {
+    await mkdir(path.join(outDir, 'lib'), { recursive: true });
+    const jszip = await readFile(path.join('lib', 'jszip.min.js'), 'utf8');
+    const sanitized = jszip.replace(/\\([0-7]{1,3})/g, (_, oct) =>
+      '\\x' + parseInt(oct, 8).toString(16).padStart(2, '0'),
+    );
+    await writeFile(path.join(outDir, 'lib', 'jszip.min.js'), sanitized);
+  } catch (err) {
+    console.warn('Skipping JSZip sanitization:', err.message);
+  }
+}
+
+async function buildScripts() {
+  await build({
+    entryPoints: ['background.ts', 'content.ts'],
+    outdir: outDir,
+    bundle: true,
+    format: 'iife',
+    target: ['chrome110'],
+    sourcemap: true,
+  });
+
+  await build({
+    entryPoints: ['popup.tsx'],
+    outdir: outDir,
+    bundle: true,
+    format: 'esm',
+    target: ['chrome110'],
+    sourcemap: true,
+  });
+}
+
+async function buildStyles() {
+  await exec(`npx tailwindcss -i popup.css -c tailwind.config.js -o ${path.join(outDir, 'popup.css')} --minify`);
+}
+
+await clean();
+await buildScripts();
+await buildStyles();
+await copyStatic();

--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,9 @@
   "background": {
     "service_worker": "background.js"
   },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval' 'inline-speculation-rules'; object-src 'self'"
+  },
   "action": {
     "default_popup": "popup.html",
     "default_icon": {
@@ -33,11 +36,5 @@
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
-  },
-  "web_accessible_resources": [
-    {
-      "resources": ["lib/jszip.min.js"],
-      "matches": ["<all_urls>"]
-    }
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "devDependencies": {
     "esbuild": "^0.20.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "tailwindcss": "^3.4.4",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   }
 }

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/popup.html
+++ b/popup.html
@@ -4,10 +4,10 @@
   <head>
     <title>Pricing Co-Pilot</title>
     <meta charset="UTF-8" />
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="popup.css" />
   </head>
   <body class="w-[350px] h-[450px] bg-slate-900 text-white font-sans">
     <div id="root"></div>
-    <script src="popup.js"></script>
+    <script type="module" src="popup.js"></script>
   </body>
 </html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['popup.html', './components/**/*.{ts,tsx}', './popup.tsx'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- bundle React and Tailwind CSS into the extension build
- drop CDN scripts and allow only self-hosted scripts in the CSP
- generate Tailwind styles during build and sanitize JSZip

## Testing
- `npm install` *(fails: 403 Forbidden fetching react and tailwindcss)*
- `npm run build` *(fails: Could not resolve "react" and "react-dom/client" due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68c09e59e4d483319766a583d72a90ed