### PR TITLE
Bundle assets locally and adjust CSP

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,3 @@
-
 {
   "manifest_version": 3,
   "name": "Pricing Co-Pilot",
@@ -22,9 +21,7 @@
     "service_worker": "background.js"
   },
   "content_security_policy": {
-
-    "extension_pages": "script-src 'self' https://cdn.tailwindcss.com https://aistudiocdn.com; object-src 'self'"
-
+    "extension_pages": "script-src 'self'; object-src 'self'"
   },
   "action": {
     "default_popup": "popup.html",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "devDependencies": {
     "esbuild": "^0.20.2",
     "jszip": "^3.10.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tailwindcss": "^3.4.4",
     "typescript": "^5.4.5"
   }
 }

--- a/popup.html
+++ b/popup.html
@@ -4,9 +4,7 @@
   <head>
     <title>Pricing Co-Pilot</title>
     <meta charset="UTF-8" />
-    <script src="https://cdn.tailwindcss.com"></script>
-
-    <script type="importmap" src="import-map.json"></script>
+    <link rel="stylesheet" href="tailwind.css" />
 
   </head>
   <body class="w-[350px] h-[450px] bg-slate-900 text-white font-sans">

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  content: [
+    './popup.html',
+    './components/**/*.{ts,tsx}',
+    './*.{ts,tsx,html}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- sanitize JSZip from node_modules and compile Tailwind CSS during build
- bundle React and use local stylesheet for popup
- tighten extension page CSP to self-only

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react)*
- `npm run build` *(fails: Could not resolve "react")*


------
https://chatgpt.com/codex/tasks/task_e_68c0c5f1c0908331a5999c46fdf745db