### PR TITLE
Handle changes to PriceLabs base price selector

### DIFF
--- a/components/PopupApp.tsx
+++ b/components/PopupApp.tsx
@@ -23,7 +23,7 @@ export const PopupApp: React.FC = () => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       const currentTab = tabs[0];
       const url = currentTab?.url ?? '';
-      if (url.includes('app.pricelabs.co') && url.includes('/listing')) {
+      if (url.includes('app.pricelabs.co/pricing?listings=')) {
         setIsPriceLabsPage(true);
       }
       setIsLoading(false);
@@ -68,7 +68,7 @@ export const PopupApp: React.FC = () => {
         <div className="text-center p-4 bg-yellow-900/50 rounded-lg m-4">
           <h3 className="font-bold text-lg text-yellow-300">Action Required</h3>
           <p className="text-yellow-100 mt-2">Please navigate to a PriceLabs listing calendar page to begin.</p>
-          <p className="text-xs text-yellow-200/60 mt-2">(URL should contain app.pricelabs.co/listing)</p>
+          <p className="text-xs text-yellow-200/60 mt-2">(URL should contain app.pricelabs.co/pricing?listings=)</p>
         </div>
       );
     }

--- a/content.ts
+++ b/content.ts
@@ -62,6 +62,31 @@ const waitForElementToDisappear = (selector: string, timeout = 10000): Promise<v
     });
 };
 
+const getBasePriceInput = async (): Promise<HTMLInputElement> => {
+    try {
+        return await waitForElement(
+            'input[data-testid="base-price-input"], input[name="basePrice"], input[id="basePrice"], input[name="base_price"], input[id="base_price"]'
+        ) as HTMLInputElement;
+    } catch {
+        const label = Array.from(document.querySelectorAll('label')).find(el => /base price/i.test(el.textContent || ''));
+        const input = label?.closest('div')?.querySelector('input');
+        if (input) return input as HTMLInputElement;
+        throw new Error('Base price input not found');
+    }
+};
+
+const getSaveRefreshButton = async (): Promise<HTMLElement> => {
+    try {
+        return await waitForElement(
+            'button[data-testid="save-and-refresh-button"], button[data-testid="save-and-refresh"], button[id="save-and-refresh-button"], button[id="save-and-refresh"], button[data-testid="save-refresh-button"], button[id="save-refresh-button"]'
+        ) as HTMLElement;
+    } catch {
+        const btn = Array.from(document.querySelectorAll('button')).find(el => /save\s*&?\s*refresh/i.test(el.textContent || ''));
+        if (btn) return btn as HTMLElement;
+        throw new Error('Save and refresh button not found');
+    }
+};
+
 chrome.runtime.onMessage.addListener((message: ContentScriptMessage, sender, sendResponse) => {
     console.log('Content script received message:', message);
 
@@ -69,16 +94,22 @@ chrome.runtime.onMessage.addListener((message: ContentScriptMessage, sender, sen
         try {
             switch (message.type) {
                 case 'GET_BASE_PRICE': {
-                    // This selector is a placeholder. You must find the correct one on PriceLabs.
-                    const input = await waitForElement('input[data-testid="base-price-input"]') as HTMLInputElement;
+                    const input = await getBasePriceInput();
                     return { type: 'BASE_PRICE_RESPONSE', price: parseFloat(input.value) };
                 }
                 case 'SET_BASE_PRICE': {
-                    const input = await waitForElement('input[data-testid="base-price-input"]') as HTMLInputElement;
+                    const input = await getBasePriceInput();
+                    input.click();
+                    input.focus();
                     input.value = message.price.toString();
                     // Dispatch events to make sure the web app's framework (e.g., React) picks up the change.
                     input.dispatchEvent(new Event('input', { bubbles: true }));
                     input.dispatchEvent(new Event('change', { bubbles: true }));
+                    return { type: 'SUCCESS' };
+                }
+                case 'CLICK_SAVE_REFRESH': {
+                    const button = await getSaveRefreshButton();
+                    button.click();
                     return { type: 'SUCCESS' };
                 }
                 case 'CLICK_ELEMENT': {

--- a/types.ts
+++ b/types.ts
@@ -23,6 +23,7 @@ export type Message =
 export type ContentScriptMessage =
   | { type: 'GET_BASE_PRICE' }
   | { type: 'SET_BASE_PRICE', price: number }
+  | { type: 'CLICK_SAVE_REFRESH' }
   | { type: 'CLICK_ELEMENT', selector: string }
   | { type: 'WAIT_FOR_ELEMENT_TO_DISAPPEAR', selector: string }
   | { type: 'WAIT_FOR_ELEMENT', selector: string }


### PR DESCRIPTION
## Summary
- Allow locating the PriceLabs base price input through several potential selectors
- Use label-based fallback to find base price input when direct selectors fail
- Add robust save-and-refresh handling and ensure base price field is focused before editing

## Testing
- `npm run build` *(fails: Could not resolve "react" and "react-dom/client")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react)*

------
https://chatgpt.com/codex/tasks/task_e_68c0cd47e3508331b9240137a687ec9a